### PR TITLE
Add benchmark gem as a dependency.

### DIFF
--- a/okcomputer.gemspec
+++ b/okcomputer.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.markdown"]
   s.test_files = Dir["test/**/*"]
 
+  s.add_dependency "benchmark"
+
   s.metadata = {
     "bug_tracker_uri"   => "#{s.homepage}/issues",
     "changelog_uri"     => "#{s.homepage}/blob/main/CHANGELOG.markdown",


### PR DESCRIPTION
When using Ruby 3.4 and okcomputer 1.19.0, the following warning appears. Based on the warning message, it seems that to use okcomputer with Ruby 3.5, the benchmark gem needs to be added as a dependency, so I did so.

```
/home/runner/work/savanna/savanna/vendor/bundle/ruby/3.4.0/gems/okcomputer-1.19.0/lib/ok_computer/check.rb:1: warning: /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/benchmark.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add benchmark to your Gemfile or gemspec to silence this warning.
Also please contact the author of okcomputer-1.19.0 to request adding benchmark into its gemspec.
```