### PR TITLE
ActionMailerCheck: Support :sendmail and :test

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,4 +1,6 @@
 #### Unreleased
+* ActionMailerCheck: Support :sendmail and :test
+  > awilfox: https://github.com/okcomputer-ruby/okcomputer/pull/21
 * Add SolidQueue checks: `SolidQueueCheck` (liveness + job stats),
   `SolidQueueBackedUpCheck` (per-queue backlog), `SolidQueueFailedJobsCheck`
   (total failed jobs), `SolidQueueFailedJobsRateCheck` (rapid increase in

--- a/lib/ok_computer/built_in_checks/action_mailer_check.rb
+++ b/lib/ok_computer/built_in_checks/action_mailer_check.rb
@@ -14,11 +14,34 @@ module OkComputer
 
     # Public: Return the status of the check
     def check
-      tcp_socket_request
-      mark_message "#{klass} check to #{host}:#{port} successful"
-    rescue => e
-      mark_message "#{klass} at #{host}:#{port} is not accepting connections: '#{e}'"
-      mark_failure
+      case klass.delivery_method
+      when :smtp
+        begin
+          tcp_socket_request
+          mark_message "#{klass} check to #{host}:#{port} successful"
+        rescue => e
+          mark_message "#{klass} at #{host}:#{port} is not accepting connections: '#{e}'"
+          mark_failure
+        end
+      when :sendmail
+        begin
+          location = klass.sendmail_settings[:location]
+          if File.executable?(location)
+            mark_message "#{klass} sendmail executable #{location} can be executed"
+          else
+            mark_message "#{klass} sendmail executable #{location} is not executable"
+            mark_failure
+          end
+        rescue => e
+          mark_message "#{klass} error checking sendmail executable: '#{e}'"
+          mark_failure
+        end
+      when :test
+        mark_message "#{klass} is in test mode"
+      else
+        mark_message "unknown delivery method #{klass.delivery_method}"
+        mark_failure
+      end
     end
   end
 end

--- a/spec/ok_computer/built_in_checks/action_mailer_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/action_mailer_check_spec.rb
@@ -54,6 +54,7 @@ module OkComputer
     describe '#check' do
       context "when mailer is accepting connections" do
         before do
+          ActionMailer::Base.delivery_method = :smtp
           ActionMailer::Base.smtp_settings[:address] = 'localhost'
           ActionMailer::Base.smtp_settings[:port] = 25
           expect(TCPSocket).to receive(:new).with('localhost', 25).and_return(double(:socket, :close => true))
@@ -64,6 +65,7 @@ module OkComputer
       end
 
       context "when mailer does not accept connection" do
+        before { ActionMailer::Base.delivery_method = :smtp }
         let(:amcheck) { described_class.new(ActionMailerSubclass) }
         it 'is not successful' do
           expect(amcheck).to receive(:tcp_socket_request).and_raise(Errno::ECONNREFUSED)
@@ -73,6 +75,35 @@ module OkComputer
           expect(amcheck).to receive(:tcp_socket_request).and_raise(Errno::ECONNREFUSED)
           expect(amcheck).to have_message "OkComputer::ActionMailerSubclass at mail.example.com:666 is not accepting connections: 'Connection refused'"
         end
+      end
+
+      context "when mailer is in sendmail mode" do
+        before do
+          ActionMailer::Base.delivery_method = :sendmail
+          ActionMailer::Base.sendmail_settings[:location] = '/usr/sbin/sendmail'
+          expect(File).to receive(:executable?).with('/usr/sbin/sendmail').and_return(true)
+        end
+
+        it { is_expected.to be_successful_check }
+        it { is_expected.to have_message "ActionMailer::Base sendmail executable /usr/sbin/sendmail can be executed" }
+      end
+
+      context "when sendmail is not installed" do
+        before do
+          ActionMailer::Base.delivery_method = :sendmail
+          ActionMailer::Base.sendmail_settings[:location] = '/usr/sbin/sendmail'
+          expect(File).to receive(:executable?).with('/usr/sbin/sendmail').and_return(false)
+        end
+
+        it { is_expected.not_to be_successful_check }
+        it { is_expected.to have_message "ActionMailer::Base sendmail executable /usr/sbin/sendmail is not executable" }
+      end
+
+      context "when mailer is in test mode" do
+        before { ActionMailer::Base.delivery_method = :test }
+
+        it { is_expected.to be_successful_check }
+        it { is_expected.to have_message "ActionMailer::Base is in test mode" }
       end
     end
   end


### PR DESCRIPTION
This adds support for checking that the `sendmail` binary chosen is executable when ActionMailer is using the `:sendmail` delivery_method, and stubs out the check when using the `:test` delivery_method.

---

My original goal with this change was to make sure OKComputer was successful during RSpec tests for both [RapidRetail](https://code.atwilcox.tech/infrastructure/mall) and [BerkeleyLibrary/framework](https://github.com/BerkeleyLibrary/framework), of which I am adding OKComputer checks to both and seeing RSpec failures when using the ActionMailer check.  I realised `:sendmail` would be pretty simple to check too, so I added that as well.

This does not add support for `:file`, but I can add it if desired.