### PR TITLE
Replace Ruby 3.5 with Ruby 4.0 in all rspec tests

### DIFF
--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -13,10 +13,15 @@ on:
         required: false
         type: string
         default: 'default'
+      continue-on-error:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   test:
     runs-on: ubuntu-24.04
+    continue-on-error: ${{ inputs.continue-on-error }}
     name: Ruby ${{ inputs.ruby }} and Rails ${{ inputs.rails }}
     env:
       RAILS_VERSION: ${{ inputs.rails }}

--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -22,7 +22,7 @@ jobs:
       RAILS_VERSION: ${{ inputs.rails }}
     steps:
       - uses: actions/checkout@v4
-      - if: ${{ inputs.rails < '6.0.0' || inputs.ruby == '3.5' }}
+      - if: ${{ inputs.rails < '6.0.0' || inputs.ruby >= '3.5' }}
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -22,11 +22,13 @@ jobs:
       RAILS_VERSION: ${{ inputs.rails }}
     steps:
       - uses: actions/checkout@v4
-      - if: ${{ inputs.rails < '6.0.0' }}
+      - if: ${{ inputs.rails < '6.0.0' || inputs.ruby == '3.5' }}
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - uses: ruby/setup-ruby@v1
         with:
           bundler: ${{ inputs.bundler }}
           bundler-cache: true
           ruby-version: ${{ inputs.ruby }}
+        env:
+          BUNDLE_FORCE_RUBY_PLATFORM: ${{ inputs.ruby == '3.5' && 'true' || 'false' }}
       - run: bundle exec rake

--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -22,7 +22,7 @@ jobs:
       RAILS_VERSION: ${{ inputs.rails }}
     steps:
       - uses: actions/checkout@v4
-      - if: ${{ inputs.rails < '6.0.0' || inputs.ruby >= '4.0' }}
+      - if: ${{ inputs.rails < '6.0.0' }}
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -13,27 +13,20 @@ on:
         required: false
         type: string
         default: 'default'
-      continue-on-error:
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   test:
     runs-on: ubuntu-24.04
-    continue-on-error: ${{ inputs.continue-on-error }}
     name: Ruby ${{ inputs.ruby }} and Rails ${{ inputs.rails }}
     env:
       RAILS_VERSION: ${{ inputs.rails }}
     steps:
       - uses: actions/checkout@v4
-      - if: ${{ inputs.rails < '6.0.0' || inputs.ruby >= '3.5' }}
+      - if: ${{ inputs.rails < '6.0.0' || inputs.ruby >= '4.0' }}
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - uses: ruby/setup-ruby@v1
         with:
           bundler: ${{ inputs.bundler }}
           bundler-cache: true
           ruby-version: ${{ inputs.ruby }}
-        env:
-          BUNDLE_FORCE_RUBY_PLATFORM: ${{ inputs.ruby == '3.5' && 'true' || 'false' }}
       - run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,10 @@ jobs:
     with:
       rails: ${{ matrix.rails }}
       ruby: ${{ matrix.ruby }}
-      continue-on-error: ${{ contains(fromJSON('["3.5", "4.0"]'), matrix.ruby) }}
     strategy:
       matrix:
         rails: [ '7.0.1', '7.1.0', '7.2.0' ]
-        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '4.0' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0' ]
         exclude:
           - { rails: '7.2.0', ruby: '2.7' }
           - { rails: '7.2.0', ruby: '3.0' }
@@ -61,8 +60,7 @@ jobs:
     with:
       rails: ${{ matrix.rails }}
       ruby: ${{ matrix.ruby }}
-      continue-on-error: ${{ contains(fromJSON('["3.5", "4.0"]'), matrix.ruby) }}
     strategy:
       matrix:
         rails: [ '8.0.0', '8.1.0' ]
-        ruby: [ '3.2', '3.3', '3.4', '3.5', '4.0' ]
+        ruby: [ '3.2', '3.3', '3.4', '4.0' ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
   test-rails-7:
     name: Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     uses: ./.github/workflows/ci-common.yml
-    continue-on-error: ${{ contains(fromJSON('["3.5", "4.0"]'), matrix.ruby) }}
     with:
       rails: ${{ matrix.rails }}
       ruby: ${{ matrix.ruby }}
+      continue-on-error: ${{ contains(fromJSON('["3.5", "4.0"]'), matrix.ruby) }}
     strategy:
       matrix:
         rails: [ '7.0.1', '7.1.0', '7.2.0' ]
@@ -58,10 +58,10 @@ jobs:
   test-rails-8:
     name: Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     uses: ./.github/workflows/ci-common.yml
-    continue-on-error: ${{ contains(fromJSON('["3.5", "4.0"]'), matrix.ruby) }}
     with:
       rails: ${{ matrix.rails }}
       ruby: ${{ matrix.ruby }}
+      continue-on-error: ${{ contains(fromJSON('["3.5", "4.0"]'), matrix.ruby) }}
     strategy:
       matrix:
         rails: [ '8.0.0', '8.1.0' ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,14 @@ jobs:
   test-rails-7:
     name: Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     uses: ./.github/workflows/ci-common.yml
+    continue-on-error: ${{ contains(fromJSON('["3.5", "4.0"]'), matrix.ruby) }}
     with:
       rails: ${{ matrix.rails }}
       ruby: ${{ matrix.ruby }}
     strategy:
       matrix:
         rails: [ '7.0.1', '7.1.0', '7.2.0' ]
-        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '3.5' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '4.0' ]
         exclude:
           - { rails: '7.2.0', ruby: '2.7' }
           - { rails: '7.2.0', ruby: '3.0' }
@@ -57,10 +58,11 @@ jobs:
   test-rails-8:
     name: Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     uses: ./.github/workflows/ci-common.yml
+    continue-on-error: ${{ contains(fromJSON('["3.5", "4.0"]'), matrix.ruby) }}
     with:
       rails: ${{ matrix.rails }}
       ruby: ${{ matrix.ruby }}
     strategy:
       matrix:
         rails: [ '8.0.0', '8.1.0' ]
-        ruby: [ '3.2', '3.3', '3.4', '3.5' ]
+        ruby: [ '3.2', '3.3', '3.4', '3.5', '4.0' ]

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+#### Unreleased
+* Replace Ruby 3.5 with Ruby 4.0 in all rspec tests
+  > emmahsax: https://github.com/emmahsax/okcomputer/pull/22
+
 #### v1.19.1
 * Add rspec for higher versions of Ruby and Rails
   > emmahsax: https://github.com/emmahsax/okcomputer/pull/19


### PR DESCRIPTION
Ruby 3.5 was only ever released as a preview, and eventually became Ruby 4.0 Therefore, we can completely remove Ruby 3.5 from the rspec matrices completely and put in Ruby 4.0