### PR TITLE
Don't use a shared closure for each spawned thread

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,4 +1,6 @@
 #### Unreleased
+* Don't use a shared closure for each spawned thread
+  > awilfox: https://github.com/okcomputer-ruby/okcomputer/pull/27
 * Add SolidQueue checks: `SolidQueueCheck` (liveness + job stats),
   `SolidQueueBackedUpCheck` (per-queue backlog), `SolidQueueFailedJobsCheck`
   (total failed jobs), `SolidQueueFailedJobsRateCheck` (rapid increase in

--- a/lib/ok_computer/check_collection.rb
+++ b/lib/ok_computer/check_collection.rb
@@ -113,10 +113,7 @@ module OkComputer
     end
 
     def check_in_parallel
-      threads = checks.map do |check|
-        Thread.new { check.run }
-      end
-      threads.each(&:join)
+      checks.map{ |check| Thread.new(check, &:run) }.each(&:join)
     end
   end
 end


### PR DESCRIPTION
I identified a memory leak in a long-running Rails app using OkComputer and found it only triggered when `check_in_parallel` was `true`.

Codex found the bug, but I authored the patch myself based on its analysis.  I did not accept its initial suggestion.

--

Using a closure here keeps the immediate environment 'live', which means all thread objects are accessible to all other threads.  This compounded a memory leak scenario in `timeout` which was keeping a single thread alive – in an app with 10 checks, it would leak all 10 threads instead of just the one with the timeout issue.